### PR TITLE
Update .on() callback data

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -26,6 +26,9 @@ After:
     PluginAPI.on('pluginElementClicked', pluginElementSelected);
     PluginAPI.on('pluginElementDeselected', pluginElementDeselected);
 
+Listeners registered with `PluginAPI.on()` will now receive the same data object that listeners registered with `PluginAPI.addListeners()` received. It was a bug the that format was different for `.on()`.
+
+It was previously possible to provide a `.params` on data sent with events, which could've been used to give multiple arguments to a callback. This was never used, and has been removed.
 
 v2.0
 ----

--- a/js/Listeners.js
+++ b/js/Listeners.js
@@ -140,7 +140,7 @@ function Listeners() {
  */
 Listeners.prototype.add = function (event, callback) {
 	if (typeof callback !== 'function') {
-		return;
+		throw Error('Listener callback must be a function.');
 	}
 
 	if (this._listeners[event] === undefined) {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -24,10 +24,11 @@ module.exports = function (config) {
 		// preprocess matching files before serving them to the browser
 		// available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
 		preprocessors: {
-			'test/**/*.js': ['webpack']
+			'test/**/*.js': ['webpack', 'sourcemap']
 		},
 
 		webpack: {
+			devtool: 'inline-source-map'
 		},
 
 		webpackMiddleware: {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "karma": "^0.13.22",
     "karma-jasmine": "^0.3.8",
     "karma-phantomjs-launcher": "^1.0.0",
+    "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^1.7.0",
     "load-grunt-tasks": "^3.5.0",
     "phantomjs-prebuilt": "^2.1.7",

--- a/test/AH5Communicator.test.js
+++ b/test/AH5Communicator.test.js
@@ -1,0 +1,66 @@
+'use strict';
+
+var communicatorFactory = require('../js/AH5Communicator');
+
+describe('AH5Communicator', function () {
+	describe('constructor', function () {
+		it('should register element select listener', function () {
+			var listeners = {};
+			var pluginApiMock = {
+				on: function (name, callback) {
+					listeners[name] = callback;
+				}
+			};
+			communicatorFactory(pluginApiMock);
+			listeners.pluginElementClicked({
+				dpArticleId: '10001'
+			});
+
+			expect(pluginApiMock.selectedPluginElement.dpArticleId).toEqual('10001');
+		});
+	});
+
+	describe('insertEmbeddedAsset', function () {
+		it('should insert element with id, attributes, class and markup', function () {
+			var requestSpy = jasmine.createSpy('request');
+			requestSpy.and.callFake(function (callSpec, data, callback) {
+				callback && callback();
+			});
+			var pluginApiMock = {
+				on: jasmine.createSpy('on'),
+				createEmbeddedObject: function (typeId, callback) {
+					callback('dpArticleId1');
+				},
+				request: requestSpy
+			};
+			var communicator = communicatorFactory(pluginApiMock);
+			communicator.insertEmbeddedAsset(
+				'<div>foo</div>',
+				{
+					embeddedTypeId: 5,
+					externalId: 'ext-id',
+					assetClass: 'dp-asset'
+				}
+			);
+
+			expect(requestSpy.calls.argsFor(0)).toContain('editor-insert-element');
+			expect(requestSpy.calls.argsFor(0)[1].element)
+				.toEqual('<div id="asset-dpArticleId1" data-internal-id="dpArticleId1" data-external-id="ext-id" class="dp-asset"><div>foo</div></div>');
+		});
+
+		it('should show error message and return if attempting to update an element created by another app', function () {
+			var showErrorMsgSpy = jasmine.createSpy('showErrorMsg');
+			var pluginApiMock = {
+				on: jasmine.createSpy('on'),
+				selectedPluginElement: true,
+				getAppName: function () {
+					return 'foo';
+				},
+				showErrorMsg: showErrorMsgSpy
+			};
+			var communicator = communicatorFactory(pluginApiMock);
+			expect(communicator.insertEmbeddedAsset('', {assetSource: 'bar'})).toBeUndefined();
+			expect(showErrorMsgSpy.calls.argsFor(0)).toContain('Can\'t update selected plugin element since it doesn\'t belong to the \'foo\' plugin');
+		});
+	});
+});

--- a/test/Listeners.test.js
+++ b/test/Listeners.test.js
@@ -1,0 +1,95 @@
+'use strict';
+
+var Listeners = require('../js/Listeners');
+
+describe('Listeners', function () {
+	var payload = {
+		source: 'DrPublish',
+		data: {foo: 'bar'}
+	};
+
+	describe('on', function () {
+		it('should register a callback', function () {
+			var listeners = new Listeners();
+			var listenerFn = function () {
+			};
+			var index = listeners.add('foo', listenerFn);
+			expect(index).toEqual(0);
+			expect(listeners._listeners.foo[index]).toEqual(listenerFn);
+		});
+
+		it('should ignore callbacks that are not a function', function () {
+			var listeners = new Listeners();
+			var index = listeners.add('foo', null);
+			expect(index).toBeUndefined();
+			expect(listeners._listeners.foo).toBeUndefined();
+		});
+	});
+
+	describe('notify', function () {
+		it('should should trigger registered listeners', function () {
+			var listeners = new Listeners();
+			var callbackSpy = jasmine.createSpy('callback');
+			var eventName = 'foo';
+			listeners.add(eventName, callbackSpy);
+			listeners.notify(eventName, payload);
+			expect(callbackSpy.calls.argsFor(0)).toContain(payload.data);
+		});
+
+		it('should should ignore removed listeners ', function () {
+			var listeners = new Listeners();
+			var callbackSpy1 = jasmine.createSpy('callback1');
+			var callbackSpy2 = jasmine.createSpy('callback2');
+			var eventName = 'foo';
+			listeners.add(eventName, callbackSpy1);
+			listeners.add(eventName, callbackSpy2);
+			listeners.remove(eventName, 0);
+			listeners.notify(eventName, payload);
+			expect(callbackSpy1.calls.count()).toEqual(0);
+			expect(callbackSpy2.calls.argsFor(0)).toContain(payload.data);
+		});
+
+		it('should should return false if any callback returns false', function () {
+			var listeners = new Listeners();
+			var callbackSpy = jasmine.createSpy('callback').and.returnValue(false);
+			var eventName = 'foo';
+			listeners.add(eventName, callbackSpy);
+			var result = listeners.notify(eventName, payload);
+			expect(result).toEqual(false);
+		});
+
+		it('should should return true when no callbacks are registered', function () {
+			var listeners = new Listeners();
+			var eventName = 'foo';
+			var result = listeners.notify(eventName, payload);
+			expect(result).toEqual(true);
+		});
+
+		it('should should return true if callback returns nothing', function () {
+			var listeners = new Listeners();
+			var callbackSpy = jasmine.createSpy('callback');
+			var eventName = 'foo';
+			listeners.add(eventName, callbackSpy);
+			var result = listeners.notify(eventName, payload);
+			expect(result).toEqual(true);
+		});
+
+		it('should should return true if callback returns null', function () {
+			var listeners = new Listeners();
+			var callbackSpy = jasmine.createSpy('callback').and.returnValue(null);
+			var eventName = 'foo';
+			listeners.add(eventName, callbackSpy);
+			var result = listeners.notify(eventName, payload);
+			expect(result).toEqual(true);
+		});
+
+		it('should should return true if callback returns truthy', function () {
+			var listeners = new Listeners();
+			var callbackSpy = jasmine.createSpy('callback').and.returnValue(true);
+			var eventName = 'foo';
+			listeners.add(eventName, callbackSpy);
+			var result = listeners.notify(eventName, payload);
+			expect(result).toEqual(true);
+		});
+	});
+});

--- a/test/Listeners.test.js
+++ b/test/Listeners.test.js
@@ -18,11 +18,11 @@ describe('Listeners', function () {
 			expect(listeners._listeners.foo[index]).toEqual(listenerFn);
 		});
 
-		it('should ignore callbacks that are not a function', function () {
+		it('should throw an error when supplied callback is not a function', function () {
 			var listeners = new Listeners();
-			var index = listeners.add('foo', null);
-			expect(index).toBeUndefined();
-			expect(listeners._listeners.foo).toBeUndefined();
+			expect(function () {
+				listeners.add('foo', null);
+			}).toThrow();
 		});
 	});
 


### PR DESCRIPTION
I got error messages about article id not being set when trying to update an existing element.

When logging the payload from DrPublish on `pluginElementClicked`, I see that the payload has a source and a data field, and that dpArticleId is available on data. In `insertElement()`, we check `PluginAPI.selectedPluginElement.dpArticleId`, which is undefined.

It looks like this is working as expected for the images plugin, though, so I'm not sure whether I'm missing something somewhere ...