### PR TITLE
Remove dependency on jQuery

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,11 +4,13 @@ Upgrading
 v3.0
 ----
 
-### Bundling with CommonJS.
+### Bundling
 
-The module is now also distributed as a bundle, so that you only need to include `bundle.js` in your own code. The external dependencies on jQuery and jquery.postmessage must also be included.
+The module is now also distributed as a bundle, so that you only need to include `bundle.js` in your own code. The external dependency on jquery.postmessage must also be included.
 
 The bundle is using UMD, so you can use your module loader of choice, or just include it in a script tag.
+
+Starting from v3, we no longer depend on jQuery, so feel free to remove it if you don't use it in your own code.
 
 ### Remove deprecated features
 

--- a/example/index.html
+++ b/example/index.html
@@ -3,11 +3,10 @@
 <head>
     <meta charset="utf-8">
     <title>Example Plugin</title>
-    <script src="http://code.jquery.com/jquery.min.js"></script>
     <script src="../dist/jquery.postmessage.js"></script>
     <script src="../dist/bundle.js"></script>
     <script>
-    $(document).ready(function() {
+    document.addEventListener('DOMContentLoaded', function() {
         var queryParameters = {};
         window.location.search.substr(1).split('&').forEach(function (queryPair) {
             queryParameters[queryPair.split('=')[0]] = queryPair.split('=')[1];
@@ -16,7 +15,7 @@
         // This is needed so that DrPublish knows which plugin to communicate with
         PluginAPI.setAppName(queryParameters.name);
 
-        $('#textButton').click(function() {
+        document.querySelector('#textButton').addEventListener('click', function() {
             var value = getValue();
             if (value === null) {
                 return false;
@@ -25,21 +24,22 @@
             PluginAPI.Editor.insertString(value);
         });
 
-        $('#objectButton').click(function() {
+        document.querySelector('#objectButton').addEventListener('click', function() {
             var value = getValue();
             if (value === null) {
                 return false;
             }
             // insert an element at the current cursor position
             // required parameters to make it draggable and non-editable are automatically added by the PluginAPI
-            var element = $('<div>').append($('<p>').attr('data-source', 'foobar').text(value));
+            var element = document.createElement('div');
+            element.innerHTML = '<p data-source="foobar">' + value + '</p>';
             PluginAPI.Editor.insertElement(element);
         });
 
         // triggers each time an element from this app is selected
         PluginAPI.on('pluginElementSelected', function(object) {
             PluginAPI.Editor.getHTMLById(object.data.id, function(element) {
-                $('#title').html('Last selected element: ' + $(element).text());
+                document.querySelector('#title').textContent = 'Last selected element: ' + element.textContent;
             });
         });
 
@@ -47,7 +47,7 @@
         PluginAPI.Editor.initMenu(['deleteButton']);
 
         function getValue() {
-            var value = $('#textInput').val();
+            var value = document.querySelector('#textInput').value;
             if (value.trim() === '') {
                 PluginAPI.showInfoMsg('I shall not insert an empty thing, that would just be silly');
                 return null;

--- a/js/AH5Communicator.js
+++ b/js/AH5Communicator.js
@@ -263,7 +263,7 @@ module.exports = function (PluginAPI) {
 			callback = options;
 		}
 		PluginAPI.request('editor-insert-element', {
-			element: jQuery('<div>').append(element).html(),
+			element: element.outerHTML,
 			select: select
 		}, callback);
 	};

--- a/js/PluginAPI.js
+++ b/js/PluginAPI.js
@@ -289,15 +289,15 @@ var PluginAPI = (function () {
 	/**
 	 * Generates proper html code to represent the dom element. This is NOT an asynchronous function
 	 *
-	 * @param {Object} dom The dom node to convert
+	 * @param {Object|Element} element The dom node to convert
 	 * @return {String} The html code
 	 */
-	// TODO: This function should also be able to take a DOMElement or similar.
-	Api.prototype.convertDomToHTML = function (dom) {
-		if (typeof dom === 'object' && typeof dom.wrap === 'function') {
-			return dom.wrap('<div>').parent().html();
+	Api.prototype.convertDomToHTML = function (element) {
+		// Support for passing in a jQuery element
+		if (typeof element === 'object' && typeof element.wrap === 'function') {
+			return element.wrap('<div>').parent().html();
 		}
-		return '';
+		return element.outerHTML;
 	};
 
 	/**

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -13,7 +13,6 @@ module.exports = function (config) {
 
 		// list of files / patterns to load in the browser
 		files: [
-			'node_modules/jquery/dist/jquery.js',
 			'js/vendors/*.js',
 			'test/*.js'
 		],

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,7 +1,7 @@
 {
 	"extends": "@aptoma/eslint-config/lib/es5.js",
 	"env": {
-		"browser": false,
+		"browser": true,
 		"jasmine": true
 	},
 	"globals": {

--- a/test/AH5Communicator.test.js
+++ b/test/AH5Communicator.test.js
@@ -20,6 +20,24 @@ describe('AH5Communicator', function () {
 		});
 	});
 
+	describe('insertElement', function () {
+		it('should send a request with the element as html', function () {
+			var requestSpy = jasmine.createSpy('request');
+			var pluginApiMock = {
+				on: jasmine.createSpy('on'),
+				request: requestSpy
+			};
+			var communicator = communicatorFactory(pluginApiMock);
+			var element = document.createElement('div');
+			element.innerHTML = '<span>Foo</span>';
+			communicator.insertElement(element, {select: true});
+
+			expect(requestSpy.calls.argsFor(0)).toContain('editor-insert-element');
+			expect(requestSpy.calls.argsFor(0)[1].element)
+				.toEqual('<div><span>Foo</span></div>');
+		});
+	});
+
 	describe('insertEmbeddedAsset', function () {
 		it('should insert element with id, attributes, class and markup', function () {
 			var requestSpy = jasmine.createSpy('request');

--- a/test/PluginAPI.test.js
+++ b/test/PluginAPI.test.js
@@ -87,8 +87,10 @@ describe('PluginAPI Core', function () {
 	});
 
 	it('should convert a dom element to an html string', function () {
-		var html = '<div><p>foobar</p></div>';
-		expect(api.convertDomToHTML($(html))).toEqual(html);
+		var element = document.createElement('div');
+		element.innerHTML = '<p>foobar</p>';
+		var expected = '<div><p>foobar</p></div>';
+		expect(api.convertDomToHTML(element)).toEqual(expected);
 	});
 
 	it('should be able to send simple requests', function () {


### PR DESCRIPTION
As we're only using jQuery for very trivial DOM stuff, it's quite overkill to depend on it. I've added the test verify the behavior, but as the old behavior was untested, I might have missed some edge cases or misuse of the old API.

