### PR TITLE
Add typedefs for embedded asset data

### DIFF
--- a/js/AH5Communicator.js
+++ b/js/AH5Communicator.js
@@ -10,6 +10,28 @@
  */
 
 /**
+ * @typedef {Object} EmbeddedAssetData
+ *
+ * @property {Number} embeddedTypeId
+ * @property {String} assetType
+ * @property {String} externalId
+ * @property {String} assetClass
+ * @property {String} assetSource The name of the app that created this asset
+ * @property {String} resourceUri
+ * @property {String} previewUri
+ * @property {String} renditions
+ * @property {AssetRendition} renditions.highRes
+ * @property {AssetRendition} renditions.preview
+ * @property {Object} options An object to hold any arbitrary extra data for this asset
+ */
+
+/**
+ * @typedef {Object} AssetRendition
+ *
+ * @property {String} uri
+ */
+
+/**
  * @param {Api} PluginAPI
  * @return {AH5Communicator}
  */
@@ -384,10 +406,19 @@ module.exports = function (PluginAPI) {
 		PluginAPI.request('total-char-count', null, callback);
 	};
 
+	/**
+	 * @param {EmbeddedAssetData} data
+	 * @param {Function} [callback]
+     */
 	AH5Communicator.prototype.updateAssetData = function (data, callback) {
 		PluginAPI.request('update-asset-media', data, callback);
 	};
 
+	/**
+	 * @param {String} markup The raw markup that will be inserted into the editer
+	 * @param {EmbeddedAssetData} data
+	 * @param {Function} [callback]
+     */
 	AH5Communicator.prototype.insertEmbeddedAsset = function (markup, data, callback) {
 		var self = this;
 		var replaceElement = false;


### PR DESCRIPTION
This should be augmented with more descriptions and examples. As far as I can tell, several of the properties need to match a predefined set of values. The allowed values should be documented.

Can we simplify this? From my understanding, we should be able to infer a few of the values, and avoid duplication. I don't have all the context though ...

`embeddedTypeId` and `assetType` seem to be pointing to the id and name of the same entity, can we remove one of them?

Is `assetClass` meant to be "anything", or should it be `dp-{assetType}`? If so, do we need to specify it? Should it have a default value?

Can `assetSource` be set by the PluginAPI? Is there a use case for this being set to something else than the active app? Could it be set to a default value if not provided?

`resourceUri` and `previewUri` duplicates the values in renditions. Are both needed?
