### PR TITLE
Handle params format in event notifications

### DIFF
--- a/js/Listeners.js
+++ b/js/Listeners.js
@@ -192,6 +192,7 @@ Listeners.prototype.removeAll = function (event) {
  * @return {Boolean} Whether to continue with the action (for events named `before*`)
  */
 Listeners.prototype.notify = function (event, payload) {
+	console.log(payload);
 	var returnValue = true;
 	if (this._listeners[event] === undefined) {
 		return returnValue;
@@ -200,16 +201,19 @@ Listeners.prototype.notify = function (event, payload) {
 	// If the payload is an object with a key data, we use that value as the payload we pass to the listener functions.
 	// This is needed as we have some inconsistencies in how we pass data around. This normalization should preferably
 	// be done at the call site.
-	var listenerPayload = payload;
-	if (typeof payload === 'object' && payload !== null && typeof payload.data !== 'undefined') {
-		listenerPayload = payload.data;
-	}
-
 	this._listeners[event].forEach(function (listenerFn) {
 		if (typeof listenerFn !== 'function') {
 			return;
 		}
-		if (listenerFn(listenerPayload) === false) {
+		var res = null;
+		if (payload.params && payload.params === true) {
+			res = listenerFn.apply(null, payload.data);
+		} else if (typeof payload === 'object' && payload !== null && typeof payload.data !== 'undefined') {
+			res = listenerFn(payload.data);
+		} else {
+			res = listenerFn(payload);
+		}
+		if (res === false) {
 			returnValue = false;
 		}
 	});

--- a/js/Listeners.js
+++ b/js/Listeners.js
@@ -205,7 +205,7 @@ Listeners.prototype.notify = function (event, payload) {
 			return;
 		}
 		var res = null;
-		if (payload.params && payload.params === true) {
+		if (payload && payload.params && payload.params === true) {
 			res = listenerFn.apply(null, payload.data);
 		} else if (typeof payload === 'object' && payload !== null && typeof payload.data !== 'undefined') {
 			res = listenerFn(payload.data);

--- a/js/Listeners.js
+++ b/js/Listeners.js
@@ -192,7 +192,6 @@ Listeners.prototype.removeAll = function (event) {
  * @return {Boolean} Whether to continue with the action (for events named `before*`)
  */
 Listeners.prototype.notify = function (event, payload) {
-	console.log(payload);
 	var returnValue = true;
 	if (this._listeners[event] === undefined) {
 		return returnValue;


### PR DESCRIPTION
Re: The issue where setting image sizes didn't work on the master branch of plugin-api.

After a lot of fiddling around, I tracked down the param issue to `Listeners.prototype.notify`, where something has clearly gone missing in one of our refactorings. There used to be extra handling for a case where the payload had a `params`-property, which would cause the callback to be executed via `Function.apply`, thus unpacking the arguments. This no longer happened, which is why we saw the arguments arrive as a single array.

For comparison, the notify function from the other branches:
```js
Listeners.prototype.notify = function(event, data) {
    "use strict";
    var returnValue = true;
	if (this._listeners[event] !== undefined) {
		jQuery.each(this._listeners[event], function(i, e) {
			if (e && typeof e === "function") {
				if (data && data.params && data.params === true) {
					var r = e.apply(null, data.data);

					if (r === false) {
						returnValue = false;
					}

				} else if (e(data) === false) {
                    returnValue = false;
                }
			}
		});
	}
	return returnValue;
};
```

The master branch, on the other hand, contains a special case for key-value payloads, which I've kept because I have no idea how any of this works anymore, and I don't dare remove it in case something else breaks.